### PR TITLE
Add a truncheon to secbelt fill, remove extra stamina damage from the truncheon.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -50,7 +50,7 @@
     contents:
       - id: GrenadeFlashBang
       - id: TearGasGrenade
-      - id: Stunbaton
+      - id: Truncheon
       - id: Handcuffs
       - id: Handcuffs
 
@@ -63,7 +63,7 @@
     contents:
     - id: GrenadeFlashBang
     - id: TearGasGrenade
-    - id: Stunbaton
+    - id: Truncheon
     - id: Handcuffs
     - id: Handcuffs
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -103,7 +103,6 @@
         Blunt: 20
     soundHit:
       collection: MetalThud
-    bluntStaminaDamageFactor: 1.5
   - type: Item
     size: Normal
   - type: Tag


### PR DESCRIPTION
## About the PR
Replaces the stun baton in the secbelt fill with a truncheon. We are taking NO prisoners.
Removes bonus stamina damage from truncheons.

## Why / Balance
Stun bad murder good

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
